### PR TITLE
Use shared SUPPORTED_PYTHON_VERSIONS in updater metadata

### DIFF
--- a/.ambient-package-update/metadata.py
+++ b/.ambient-package-update/metadata.py
@@ -4,6 +4,7 @@ from ambient_package_update.metadata.constants import (
     DEV_DEPENDENCIES,
     LICENSE_MIT,
     SUPPORTED_DJANGO_VERSIONS,
+    SUPPORTED_PYTHON_VERSIONS,
 )
 from ambient_package_update.metadata.maintainer import PackageMaintainer
 from ambient_package_update.metadata.package import PackageMetadata
@@ -33,12 +34,7 @@ METADATA = PackageMetadata(
         f"Django>={SUPPORTED_DJANGO_VERSIONS[0]}",
     ],
     supported_django_versions=SUPPORTED_DJANGO_VERSIONS,
-    supported_python_versions=[
-        "3.10",
-        "3.11",
-        "3.12",
-        "3.13",
-    ],
+    supported_python_versions=SUPPORTED_PYTHON_VERSIONS,
     optional_dependencies={
         "dev": [
             *DEV_DEPENDENCIES,


### PR DESCRIPTION
queuebie hardcoded ["3.10".."3.13"] instead of importing the shared constant, so it missed the org-wide drop of 3.10 (and addition of 3.14). Switch to SUPPORTED_PYTHON_VERSIONS so the next updater run regenerates requires-python, classifiers, CI matrix and ruff target-version in line with the other packages.